### PR TITLE
Added missing package net-tools (provide ifconfig)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -q -y update \
  && apt-get -q -y install runit \
                           telnet \
+                          net-tools \
                           postfix \
                           rsyslog \
                           clamav clamav-daemon amavisd-new spamassassin razor pyzor \


### PR DESCRIPTION
Hello,

when started, the following error appears in the logs :
`/usr/local/bin/list-available-networks.sh: line 31: ifconfig: command not found`
This prevent `AUTO_TRUST_NETWORKS` to work

This PR aims to install the missing package.

Regards,
    Nicolas.